### PR TITLE
Read Only JSON DB Service

### DIFF
--- a/src/left/database/readonlydbservice.py
+++ b/src/left/database/readonlydbservice.py
@@ -14,7 +14,7 @@ class ReadOnlyJSONDBService:
     def __init__(self, db_file):
         try:
             self._data = load(db_file)
-        except TypeError:
+        except (TypeError, AttributeError):
             self._data = load(open(db_file))
 
     def get_resource(self, table_name=None, key_name="uid") -> ReadOnlyJSONDBResource:

--- a/src/left/database/readonlydbservice.py
+++ b/src/left/database/readonlydbservice.py
@@ -1,0 +1,124 @@
+"""
+Stand-in for TinyDb in situations where the app is to be deployed in read-only mode from a static JSON file
+(in tinydb format)
+"""
+
+from __future__ import annotations
+from typing import Optional, List, Dict, Callable
+from json import load
+
+from .documentrecordservice import DocumentRecordService
+
+
+class ReadOnlyJSONDBService:
+    def __init__(self, db_file):
+        try:
+            self._data = load(db_file)
+        except TypeError:
+            self._data = load(open(db_file))
+
+    def get_resource(self, table_name=None, key_name="uid") -> ReadOnlyJSONDBResource:
+        resource = self._data
+        if table_name is not None:
+            resource = self._data[table_name].values()
+        return ReadOnlyJSONDBResource(resource, key_name)
+
+    def __getattr__(self, item):
+        return getattr(self.get_resource(), item)
+
+    def flush(self):
+        raise NotImplementedError("flush() not available on a read only db")
+
+    def close(self):
+        pass
+
+
+class Resource:
+    def __init__(self, data: Dict):
+        self.data = data
+
+    def search(self, condition: Condition) -> List:
+        return list(filter(lambda o: condition(o), self.data))
+
+
+class Condition:
+    def __init__(self, f: Callable):
+        self.f = f
+
+    def __call__(self, resource: Dict) -> bool:
+        return self.f(resource)
+
+    def __or__(self, other: Condition) -> Condition:
+        def f(resource):
+            return self(resource) or other(resource)
+        return Condition(f)
+
+    def __and__(self, other: Condition) -> Condition:
+        def f(resource):
+            return self(resource) and other(resource)
+        return Condition(f)
+
+
+class Where:
+    def __init__(self, key):
+        self.key = key
+
+    def exists(self) -> Condition:
+        def f(resource):
+            return self.key in resource
+        return Condition(f)
+
+    def test(self, value) -> Condition:
+        def f(resource):
+            try:
+                return resource[self.key] == value
+            except KeyError:
+                return False
+        return Condition(f)
+
+
+class ReadOnlyJSONDBResource(DocumentRecordService):
+    def __init__(self, resource, key_name):
+        self.resource = Resource(resource)
+        self.key_name = key_name
+
+    def create(self, **kwargs) -> str:
+        raise NotImplementedError("create() not available on a read only db")
+
+    def read(self,
+             offset: Optional[int] = None,
+             limit: Optional[int] = None,
+             operator="and", **kwargs) -> List[Dict]:
+
+        condition = Where(self.key_name).exists()
+        i = 0
+        for k, v in kwargs.items():
+            if callable(v):
+                if operator == "or" and i > 0:
+                    condition = condition | (Where(k).test(v))
+                else:
+                    condition = condition & (Where(k).test(v))
+                i = i + 1
+                continue
+            if operator == "or" and i > 0:
+                condition = condition | Where(k).test(v)
+            else:
+                condition = condition & Where(k).test(v)
+            i = i + 1
+        items = self.resource.search(condition)
+        if offset is not None:
+            if limit is not None:
+                return items[offset: offset+limit]
+            return items[offset:]
+        elif limit is not None:
+            return items[:limit]
+        return items
+
+    def update(self, key_value, **kwargs):
+        raise NotImplementedError("update() not available on a read only db")
+
+    def destroy(self, key_value):
+        raise NotImplementedError("destroy() not available on a read only db")
+
+    def bulk_insert(self, docs_to_insert):
+        raise NotImplementedError("bulk_insert() not available on a read only db")

--- a/test/testreadonlyjsondbservice.py
+++ b/test/testreadonlyjsondbservice.py
@@ -1,0 +1,59 @@
+import json
+import unittest
+from unittest import TestCase
+from typing import List
+from io import StringIO
+
+from left.database.readonlydbservice import ReadOnlyJSONDBService
+
+
+class TestTinyDBService(TestCase):
+
+    @staticmethod
+    def _make_data(data: List):
+        db_file = StringIO(json.dumps(data))
+        return ReadOnlyJSONDBService(db_file)
+
+    def test_read_can_return_all_records(self):
+        db = self._make_data([{"uid": "foo"}, {"uid": "bar"}])
+        records = db.read()
+        assert records == [{"uid": "foo"}, {"uid": "bar"}]
+
+    def test_can_read_records_with_matching_attribute(self):
+        db = self._make_data([{"uid": 1, "bar": "foo"}, {"uid": 2, "foo": "bar"}])
+        records = db.read(bar="foo")
+        assert records == [{"uid": 1, "bar": "foo"}]
+
+    def test_can_read_records_with_specific_key(self):
+        db = self._make_data([{"uid": "foo"}, {"uid": "bar"}])
+        records = db.read(uid="bar")
+        assert records == [{"uid": "bar"}]
+
+    def test_read_can_specify_offset(self):
+        db = self._make_data([{"uid": "foo"}, {"uid": "bar"}])
+        records = db.read(offset=1)
+        assert records == [{"uid": "bar"}]
+
+    def test_read_can_specify_limit(self):
+        db = self._make_data([{"uid": "foo"}, {"uid": "bar"}])
+        records = db.read(limit=1)
+        assert records == [{"uid": "foo"}]
+
+    def test_read_can_specify_offset_and_limit(self):
+        db = self._make_data([{"uid": "foo"}, {"uid": "bar"}, {"uid": None}])
+        records = db.read(offset=1, limit=1)
+        assert records == [{"uid": "bar"}]
+
+    def test_can_use_resource(self):
+        db = self._make_data({
+            "my_table": {
+                "1": {"my_key": 1},
+                "2": {"my_key": 2}
+            }
+        })
+        resource = db.get_resource(table_name="my_table", key_name="my_key")
+        assert resource.read(my_key=1) == [{"my_key": 1}]
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
In some cases it might be useful to deploy an app as a read-only flutter web app using a small DB in JSON format.
This allows for swapping out the tinydb implementation with a service that reads from a bundled json file (in tinydb record format).

Of course, if the app is rendered client-side, the contents of the database are visible, **so this only for use cases where all the data is deemed publicly accessible**,

Potentially, app contents could be crafted using the TinyDB service, and then this is swapped out for the read-only implementation when the app is published (eg `flet build web`)