### PR TITLE
Allow Better Control of DB Cache Behaviour

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 flet==0.24.1
 dataclasses_json==0.6.3
 # slugify==0.0.1
-tinydb==4.8.0
+tinydb==4.8.2
 tinyrecord==0.2.0
 setuptools==69.0.3
 # pillow==10.4.0

--- a/src/left/database/tinydbservice.py
+++ b/src/left/database/tinydbservice.py
@@ -38,7 +38,7 @@ def resource_lock(f):
 
 
 class TinyDBService:
-    def __init__(self, db_file, write_through=True):
+    def __init__(self, db_file, write_through=True, read_query_cache_size=30):
         """
         :param db_file: name of the file where the JSON data will be stored
         :param write_through: if True (default) each write is written to the cache and saved straight away.
@@ -48,11 +48,12 @@ class TinyDBService:
         if write_through:
             middleware.WRITE_CACHE_SIZE = 1
         self.db = TinyDB(db_file, storage=middleware)
+        self.read_query_cache_size = read_query_cache_size
 
     def get_resource(self, table_name=None, key_name="uid") -> TinyDBResource:
         resource = self.db
         if table_name is not None:
-            resource = self.db.table(table_name)
+            resource = self.db.table(table_name, cache_size=self.read_query_cache_size)
         return TinyDBResource(resource, key_name)
 
     def __getattr__(self, item):

--- a/src/left/database/tinydbservice.py
+++ b/src/left/database/tinydbservice.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import logging
-from contextlib import contextmanager
 from typing import Optional, List, Dict
 from threading import Lock, get_ident
 


### PR DESCRIPTION
I noticed that the window close event was not getting called when the interrupt signal (ie CTRL-C) was sent to the app. This would lead to cached writes not being flushed to the storage.

Ideally, the interrupt signal should never be blocked, and given that my primary use-case for this framework is for single-user desktop tools where the tinydb database is being used for **simple app configuration data** (ie read-centric) it seems like the best strategy here is to adopt a write-through strategy. (There are better database solutions for read-write intensive use-cases...)

- Update TinyDB
- Set TinyDBService to operate in a write-through cache mode (probably the desired default behavior given the above)
- Allow the user to alter the size of the read query cache